### PR TITLE
Fix multi-commodity transactions, add preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ library. The input structure is:
         ...
         <val>string<val>
       </fuel_outrecipes>
-      <assem_size>double<assem_size>
+      <assem_size>double</assem_size>
       <cycle_time>int</cycle_time>
       <refuel_time>int</refuel_time>
       <n_assem_core>int</n_assem_core>
       <n_assem_batch>int</n_assem_batch>
       <power_cap>double</power_cap>
-    </DeployReactor>
+    </DepleteReactor>
 
 The `fuel_prefs`, `fuel_inrecipes` and `fuel_outrecipes` state variables are optional, but 
 must be of equal length to the `fuel_incommods` or `fuel_outcommods`.

--- a/examples/complex.xml
+++ b/examples/complex.xml
@@ -55,6 +55,7 @@
         <Source>
           <outcommod>mox</outcommod>
           <outrecipe>mox</outrecipe>
+          <throughput>10</throughput>
         </Source>
       </config>
       <name>TwoSource</name>

--- a/examples/simple.xml
+++ b/examples/simple.xml
@@ -15,10 +15,6 @@
             <name>Sink</name>
         </spec>
         <spec>
-            <lib>cycamore</lib>
-            <name>Reactor</name>
-        </spec>
-        <spec>
             <lib>agents</lib>
             <name>NullRegion</name>
         </spec>
@@ -72,25 +68,6 @@
           </DepleteReactor>
         </config>
     </facility>
-
-    <facility>
-        <name>TwoReactor</name>
-        <config>
-	  <Reactor>
-            <fuel_incommods> <val>uox</val> </fuel_incommods>
-            <fuel_outcommods> <val>spent_uox</val> </fuel_outcommods>
-            <fuel_inrecipes> <val>uox</val> </fuel_inrecipes>
-            <fuel_outrecipes> <val>spent_uox</val> </fuel_outrecipes>
-            <assem_size>10</assem_size>
-            <cycle_time>2</cycle_time>
-            <refuel_time>1</refuel_time>
-            <n_assem_core>3</n_assem_core>
-            <n_assem_batch>1</n_assem_batch>
-            <power_cap>100</power_cap>
-          </Reactor>
-        </config>
-    </facility>
-
    <region>
         <config>
             <NullRegion>
@@ -114,10 +91,6 @@
               <number>1</number>
               <prototype>OneReactor</prototype>
             </entry>  
-            <!--entry>
-              <number>1</number>
-              <prototype>TwoReactor</prototype>
-            </entry-->  
           </initialfacilitylist>
           <name>OneInst</name>
         </institution>

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -281,11 +281,12 @@ class DepleteReactor(Facility):
             for jj in range(0, len(self.fuel_incommods)):
                 commod = self.fuel_incommods[jj]
                 pref = self.fuel_prefs[jj]
-                recipe = self.context.get_recipe(commod)
+                recipe = self.context.get_recipe(self.fuel_inrecipes[jj])
                 material = ts.Material.create_untracked(self.assem_size, recipe)
-            lib.record_time_series("demand"+commod, self, self.assem_size)
-            port.append({"commodities":{commod:material}, "constraints":self.assem_size})
-        print("time:", self.context.time, "finish get_material_requests")
+            port.append({"commodities":{commod:material}, "preference":pref,"constraints":self.assem_size})
+            max_index = 1
+            lib.record_time_series("demand"+self.fuel_incommods[max_index], self, self.assem_size)
+            print("time:", self.context.time, "finish get_material_requests")
         return port
 
     def get_material_bids(self, requests): # phase 2

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -233,7 +233,7 @@ class DepleteReactor(Facility):
     def enter_notify(self):
         super().enter_notify()       
         if len(self.fuel_prefs) == 0:
-            self.fuel_prefs = [0]*len(self.fuel_incommods)
+            self.fuel_prefs = [1]*len(self.fuel_incommods)
   
     def check_decommission_condition(self):
         '''

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -264,7 +264,7 @@ class DepleteReactor(Facility):
         submit no bids for materials.
         '''
         port = []
-        n_assem_order = self.n_assem_core - self.core.count + self.n_assem_fresh + self.fresh_fuel.count
+        n_assem_order = self.n_assem_core - self.core.count + self.n_assem_fresh - self.fresh_fuel.count
         print("time:", self.context.time, "request", n_assem_order, "assemblies")
         if self.exit_time != -1:
             time_left = self.exit_time - self.context.time + 1

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -8,8 +8,6 @@ from openmcyclus.depletion import Depletion
 import openmc.deplete as od
 
 
-
-
 class DepleteReactor(Facility):
     '''
     Archetype class to model a reactor facility that is
@@ -121,14 +119,14 @@ class DepleteReactor(Facility):
     )
 
     model_path = ts.String(
-        doc = "Path to files with the OpenMC model information",
-        tooltip = "Path to files with OpenMC model",
-        default = "/home/abachmann/openmcyclus/tests/"
+        doc="Path to files with the OpenMC model information",
+        tooltip="Path to files with OpenMC model",
+        default="/home/abachmann/openmcyclus/tests/"
     )
 
     chain_file = ts.String(
-        doc = "File with OpenMC decay chain information",
-        tooltip = "Absolute path to decay chain file"
+        doc="File with OpenMC decay chain information",
+        tooltip="Absolute path to decay chain file"
     )
     fresh_fuel = ts.ResBufMaterialInv()
     core = ts.ResBufMaterialInv()
@@ -145,10 +143,10 @@ class DepleteReactor(Facility):
         self.power_name = "power"
         self.discharged = False
         self.resource_indexes = {}
-        self.deplete = Depletion(self.model_path, 
-                                 self.prototype, self.chain_file, 
+        self.deplete = Depletion(self.model_path,
+                                 self.prototype, self.chain_file,
                                  self.cycle_time, self.power_cap)
-        
+
     def tick(self):
         '''
         Logic to implement at the tick phase of each
@@ -163,7 +161,7 @@ class DepleteReactor(Facility):
         fuel is loaded
         '''
         if self.retired():
-        #    self.record("RETIRED", "")
+            #    self.record("RETIRED", "")
             if self.context.time == self.exit_time + 1:
                 if self.decom_transmute_all == 1:
                     self.transmute(math.ceil(self.n_assem_core))
@@ -245,9 +243,9 @@ class DepleteReactor(Facility):
 
     def enter_notify(self):
         '''
-        Calls the enter_notify method of the parent class. 
-        Also defines a list for the input commodity preferences if 
-        not are provided by the user. 
+        Calls the enter_notify method of the parent class.
+        Also defines a list for the input commodity preferences if
+        not are provided by the user.
         '''
         super().enter_notify()
         if len(self.fuel_prefs) == 0:
@@ -295,7 +293,7 @@ class DepleteReactor(Facility):
         --------
         ports: list of dictionaries
             Format: [{"commodities":
-                      [{commod_name(str):Material object, 
+                      [{commod_name(str):Material object,
                         "preference":int/float}, ...],
                       "constraints:int/float}, ...]
             Defines the request portfolio for the facility.
@@ -368,7 +366,7 @@ class DepleteReactor(Facility):
         Returns:
         --------
         port: dict
-            dictionary of materials held by facility that meets a request 
+            dictionary of materials held by facility that meets a request
             from another facility
         '''
         got_mats = False
@@ -426,14 +424,14 @@ class DepleteReactor(Facility):
         Parameters:
         -----------
         trades: tuple
-            tuple of material objects requested matched to the 
+            tuple of material objects requested matched to the
             material responses
 
         Returns:
         --------
         responses: dict
-            dictionary of {Material object:Material object}. The 
-            key is the Material request being matched. The value is the 
+            dictionary of {Material object:Material object}. The
+            key is the Material request being matched. The value is the
             Material in the spent fuel inventory
         '''
         responses = {}
@@ -467,11 +465,11 @@ class DepleteReactor(Facility):
         Parameters:
         -----------
         responses: dict
-            dictionary of {Material object:Material object}. The 
-            key is the Material request being matched. The value is the 
+            dictionary of {Material object:Material object}. The
+            key is the Material request being matched. The value is the
             Material in the spent fuel inventory
 
-        
+
         '''
         n_load = len(responses)
         if n_load > 0:
@@ -503,16 +501,16 @@ class DepleteReactor(Facility):
 
     def discharge(self):
         '''
-        Determine the number of assemblies to discharge. If the space for 
-        spent fuel assemblies is less than the number that need 
+        Determine the number of assemblies to discharge. If the space for
+        spent fuel assemblies is less than the number that need
         to be discharged, then don't discharge and return false
 
-        Record the number of assemblies discharged. 
+        Record the number of assemblies discharged.
 
         Remove the correct number of assemblies from the core.
-        Get the name of each spent fuel assembly. Then get the 
-        mass of each spent fuel commodity discharged. Return true if the 
-        fuel has been discharged. 
+        Get the name of each spent fuel assembly. Then get the
+        mass of each spent fuel commodity discharged. Return true if the
+        fuel has been discharged.
 
         Returns:
         --------
@@ -586,14 +584,15 @@ class DepleteReactor(Facility):
             self.core.push(old[ii])
         ss = str(len(old)) + " assemblies"
         # self.record("TRANSMUTE", ss)
-        for ii in range(len(old)):       
+        for ii in range(len(old)):
             model = self.deplete.read_model()
             micro_xs = self.deplete.read_microxs()
-            ind_op = od.IndependentOperator(model.materials, micro_xs,
-                                            str(self.model_path + self.chain_file))
+            ind_op = od.IndependentOperator(
+                model.materials, micro_xs, str(
+                    self.model_path + self.chain_file))
             ind_op.output_dir = self.model_path
             integrator = od.PredictorIntegrator(ind_op, np.ones(
-                int(self.cycle_time)*30), power=int(self.power_cap)*1000*3, 
+                int(self.cycle_time) * 30), power=int(self.power_cap) * 1000 * 3,
                 timestep_units='d')
             integrator.integrate()
 
@@ -633,7 +632,7 @@ class DepleteReactor(Facility):
         Parameters:
         -----------
         material: Material
-            Cyclus Material object to be checked 
+            Cyclus Material object to be checked
         incommod: str
             commodity name to compare against
         '''
@@ -661,7 +660,7 @@ class DepleteReactor(Facility):
         Returns:
         --------
         mapped: dict
-            Keys are the commodity names (str) and the values are 
+            Keys are the commodity names (str) and the values are
             lists of Material objects from the spent fuel inventory
         '''
         mats = self.spent_fuel.pop_n(self.spent_fuel.count)
@@ -680,8 +679,8 @@ class DepleteReactor(Facility):
         Parameters:
         -----------
         leftover: dict
-            Keys are the commodity names (str). Values are a list of 
-            Material objects. 
+            Keys are the commodity names (str). Values are a list of
+            Material objects.
         '''
         for commod in leftover:
             leftover[commod].reverse
@@ -691,14 +690,14 @@ class DepleteReactor(Facility):
 
     def peek_spent(self):
         '''
-        Creates a dictionary of the materials in the spent 
-        fuel inventory based on their commodity name. 
+        Creates a dictionary of the materials in the spent
+        fuel inventory based on their commodity name.
 
         Returns:
         --------
         mapped: dict
-            Keys are the commodity names of the spent fuel. 
-            Values are the Materials with the given commodity names. 
+            Keys are the commodity names of the spent fuel.
+            Values are the Materials with the given commodity names.
 
         '''
         mapped = {}
@@ -718,14 +717,14 @@ class DepleteReactor(Facility):
         Parameters:
         -----------
         material: Material obj
-            Material object to be queried 
+            Material object to be queried
         flow: str
             input or output commodity. "in" if input, "out"
-            if output commodity. 
+            if output commodity.
 
         Return:
         -------
-        string 
+        string
             name of commodity for the queried material
         '''
         ii = self.resource_indexes[material.obj_id]
@@ -742,14 +741,14 @@ class DepleteReactor(Facility):
         Parameters:
         -----------
         material: Material obj
-            Material object to be queried 
+            Material object to be queried
         flow: str
             input or output recipe. "in" if input, "out"
-            if output recipt. 
+            if output recipt.
 
         Return:
         -------
-        string 
+        string
             name of recipe for the queried material
         '''
         ii = self.resource_indexes[material.obj_id]
@@ -766,11 +765,11 @@ class DepleteReactor(Facility):
         Parameters:
         -----------
         material: Material obj
-            Material object to be queried. 
+            Material object to be queried.
 
         Return:
         -------
-        string 
+        string
             preference for the queried material
         '''
         ii = self.resource_indexes[material.obj_id]

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -570,10 +570,10 @@ class DepleteReactor(Facility):
         core_pop = self.core.pop_n(npop)
         for ii in range(len(core_pop)):
             self.spent_fuel.push(core_pop[ii])
-        tot_spent = 0
 
         for ii in range(len(self.fuel_outcommods)):
             spent_mats = self.peek_spent()
+            tot_spent = 0
             if self.fuel_outcommods[ii] in spent_mats:
                 mats = spent_mats[self.fuel_outcommods[ii]]
                 tot_spent += mats.quantity

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -1,14 +1,15 @@
-from cyclus.agents import Facility 
+from cyclus.agents import Facility
 from cyclus import lib
 import cyclus.typesystem as ts
 import math
 
+
 class DepleteReactor(Facility):
     '''
-    Archetype class to model a reactor facility that is 
+    Archetype class to model a reactor facility that is
     coupled to the stand alone depletion solver in OpenMC.
-    With the exception of the depletion solver, this 
-    archetype has the same functionality as the 
+    With the exception of the depletion solver, this
+    archetype has the same functionality as the
     cycamore:Reactor archetype.
     '''
 
@@ -19,16 +20,16 @@ class DepleteReactor(Facility):
     )
 
     fuel_inrecipes = ts.VectorString(
-        doc = "Fresh fuel recipe",
-        tooltip = "Fresh fuel recipe",
-        uilabel = "Input commodity recipe"
+        doc="Fresh fuel recipe",
+        tooltip="Fresh fuel recipe",
+        uilabel="Input commodity recipe"
     )
-    
+
     fuel_prefs = ts.VectorDouble(
-        doc = "Fuel incommod preference",
-        tooltip = "Fuel incommod preference",
-        uilabel = "Fuel incommod preference",
-        default = []
+        doc="Fuel incommod preference",
+        tooltip="Fuel incommod preference",
+        uilabel="Fuel incommod preference",
+        default=[]
     )
 
     fuel_outcommods = ts.VectorString(
@@ -39,80 +40,80 @@ class DepleteReactor(Facility):
     )
 
     fuel_outrecipes = ts.VectorString(
-        doc = "Spent fuel recipe",
-        tooltip = "Spent fuel recipe",
-        uilabel = "Output commodity recipe"
+        doc="Spent fuel recipe",
+        tooltip="Spent fuel recipe",
+        uilabel="Output commodity recipe"
     )
 
     assem_size = ts.Double(
-        doc = "Mass (kg) of a single fuel assembly",
+        doc="Mass (kg) of a single fuel assembly",
         tooltip="Mass (kg) of a single fuel assembly",
         uilabel="Assembly Size",
         units="kg",
-        default= 0
+        default=0
     )
 
     cycle_time = ts.Double(
         doc="Amount of time between requests for new fuel",
-        tooltip = "Amount of time between requests for new fuel",
+        tooltip="Amount of time between requests for new fuel",
         uilabel="Cycle Time",
         units="months",
         default=0
     )
 
     refuel_time = ts.Int(
-        doc = "Time steps for refueling",
+        doc="Time steps for refueling",
         tooltip="Time steps for refueling",
         uilabel="refueltime",
-        default = 0
-    )
-
-    n_assem_core = ts.Int(
-        doc = "Number of assemblies in a core",
-        tooltip = "Number of assemblies in a core",
-        uilabel = "n_assem_core",
         default=0
     )
 
-    n_assem_batch = ts.Int( 
-        doc = "Number of assemblies per batch",
-        tooltip = "Number of assemblies per batch",
-        uilabel = "n_assem_batch",
+    n_assem_core = ts.Int(
+        doc="Number of assemblies in a core",
+        tooltip="Number of assemblies in a core",
+        uilabel="n_assem_core",
+        default=0
+    )
+
+    n_assem_batch = ts.Int(
+        doc="Number of assemblies per batch",
+        tooltip="Number of assemblies per batch",
+        uilabel="n_assem_batch",
         default=0
     )
 
     n_assem_fresh = ts.Int(
-        doc = "Number of fresh fuel assemblies to keep on hand "\
-              "if possible",
-        default = 0,
-        range = [0,3],
+        doc="Number of fresh fuel assemblies to keep on hand "
+        "if possible",
+        default=0,
+        range=[0, 3],
         uilabel="Minimum fresh fuel inventory",
-        units = "assemblies"
+        units="assemblies"
     )
 
     n_assem_spent = ts.Int(
-        doc = "Number of spent fuel assemblies that can be stored "\
-              "on-site before reactor operation stalls",
-        default = 10000000,
+        doc="Number of spent fuel assemblies that can be stored "
+        "on-site before reactor operation stalls",
+        default=10000000,
         uilabel="Maximum spent fuel inventory",
-        units = "assemblies"
+        units="assemblies"
     )
 
     power_cap = ts.Double(
-        doc = "Maximum amount of power (MWe) produced",
-        tooltip = "Maximum amount of power (MWe) produced",
-        uilabel = "power_cap",
-        units = "MW",
+        doc="Maximum amount of power (MWe) produced",
+        tooltip="Maximum amount of power (MWe) produced",
+        uilabel="power_cap",
+        units="MW",
         default=0
     )
 
     decom_transmute_all = ts.String(
-        doc = "If true, the archetype transmutes all assemblies "\
-              "upon decommisioning. If false, the archetype only "\
-              "transmutes half.",
-        default = 0
+        doc="If true, the archetype transmutes all assemblies "
+        "upon decommisioning. If false, the archetype only "
+        "transmutes half.",
+        default=0
     )
-   
+
     fresh_fuel = ts.ResBufMaterialInv()
     core = ts.ResBufMaterialInv()
     spent_fuel = ts.ResBufMaterialInv()
@@ -121,25 +122,25 @@ class DepleteReactor(Facility):
         super().__init__(*args, **kwargs)
         self.fresh_fuel_entry_times = []
         self.core_entry_times = []
-        self.fresh_fuel.capacity = self.assem_size*self.n_assem_fresh
-        self.core.capacity = self.assem_size*self.n_assem_core
-        self.spent_fuel.capacity = self.assem_size*self.n_assem_spent
+        self.fresh_fuel.capacity = self.assem_size * self.n_assem_fresh
+        self.core.capacity = self.assem_size * self.n_assem_core
+        self.spent_fuel.capacity = self.assem_size * self.n_assem_spent
         self.cycle_step = 0
         self.power_name = "power"
         self.discharged = False
         self.resource_indexes = {}
-    
+
     def tick(self):
         '''
-        Logic to implement at the tick phase of each 
-        time step. 
-        
-        If the prototype is retired, then that is recorded, 
-        fuel is transmuted, and the prototype is decommissioned. 
+        Logic to implement at the tick phase of each
+        time step.
 
-        If it's the end of a cycle, that is recorded. If it is 
-        after a cycle ends, and fuel has not been discharged, 
-        then the fuel is discharged. If it's after a cycle ends, then 
+        If the prototype is retired, then that is recorded,
+        fuel is transmuted, and the prototype is decommissioned.
+
+        If it's the end of a cycle, that is recorded. If it is
+        after a cycle ends, and fuel has not been discharged,
+        then the fuel is discharged. If it's after a cycle ends, then
         fuel is loaded
         '''
         print("time:", self.context.time, "tick")
@@ -150,23 +151,33 @@ class DepleteReactor(Facility):
                 if self.decom_transmute_all == 1:
                     self.transmute(math.ceil(self.n_assem_core))
                 else:
-                    self.transmute(math.ceil(self.n_assem_core/2))
+                    self.transmute(math.ceil(self.n_assem_core / 2))
 
             while self.core.count > 0:
                 if self.discharge() == False:
                     break
             print("time:", self.context.time, "end discharge loop")
-            while (self.fresh_fuel.count > 0) and (self.spent_fuel.space >= self.assem_size):
+            while (
+                    self.fresh_fuel.count > 0) and (
+                    self.spent_fuel.space >= self.assem_size):
                 self.spent_fuel.push(self.fresh_fuel.pop())
 
-            print("time:", self.context.time, "decommission?", self.check_decommission_condition())
+            print(
+                "time:",
+                self.context.time,
+                "decommission?",
+                self.check_decommission_condition())
             if self.check_decommission_condition():
                 self.decommission()
-                
 
         print("time:", self.context.time, "end retired loop")
-        if self.cycle_step == self.cycle_time:   
-            print("time:", self.context.time, "transmute", math.ceil(self.n_assem_batch))     
+        if self.cycle_step == self.cycle_time:
+            print(
+                "time:",
+                self.context.time,
+                "transmute",
+                math.ceil(
+                    self.n_assem_batch))
             self.transmute(math.ceil(self.n_assem_batch))
 
         if (self.cycle_step >= self.cycle_time) and (self.discharged == False):
@@ -178,45 +189,50 @@ class DepleteReactor(Facility):
             print("time:", self.context.time, self.fresh_fuel.count)
             self.load()
 
-        #lib.Logger('5', str("DepleteReactor" + str(self.power_cap) + "is ticking"))
+        # lib.Logger('5', str("DepleteReactor" + str(self.power_cap) + "is ticking"))
         print("time:", self.context.time, "end tick")
         return
- 
+
     def tock(self):
         '''
-        Logic to implement at the tock phase of each 
-        time step. 
+        Logic to implement at the tock phase of each
+        time step.
 
-        If the prototype is retired, then nothing happens. 
+        If the prototype is retired, then nothing happens.
 
         If it's after a cycle ends and the refueling time has passed,
-        the core is full, and fuel has been discharged, then 
-        the discharged variable is changed to false and the 
+        the core is full, and fuel has been discharged, then
+        the discharged variable is changed to false and the
         cycle length counter is restarted.
 
-        If it's the beginning of a new cycle and the core is full, 
-        then a cycle start is recorded. 
+        If it's the beginning of a new cycle and the core is full,
+        then a cycle start is recorded.
 
-        If it's in the middle of a cycle and the core is full, the 
-        the power_cap value is recorded as power generated. If these 
-        conditions aren't met, then a power of 0 is recorded. 
+        If it's in the middle of a cycle and the core is full, the
+        the power_cap value is recorded as power generated. If these
+        conditions aren't met, then a power of 0 is recorded.
 
-        If it's in the middle of a cycle or the core is full, then 
-        the cycle duration counter increases by one. 
+        If it's in the middle of a cycle or the core is full, then
+        the cycle duration counter increases by one.
         '''
         print("time:", self.context.time, "tock")
         if self.retired():
             return
-        
-        if (self.cycle_step >= self.cycle_time+self.refuel_time) and (self.core.count == self.n_assem_core) and (self.discharged == True):
+
+        if (
+            self.cycle_step >= self.cycle_time +
+            self.refuel_time) and (
+            self.core.count == self.n_assem_core) and (
+                self.discharged):
             self.discharged = False
             self.cycle_step = 0
-        
+
         if (self.cycle_step == 0) and (self.core.count == self.n_assem_core):
-            #self.record("CYCLE_START", "")
+            # self.record("CYCLE_START", "")
             print("Cycle start")
 
-        if (self.cycle_step >=0) and (self.cycle_step < self.cycle_time) and (self.core.count == self.n_assem_core):
+        if (self.cycle_step >= 0) and (self.cycle_step < self.cycle_time) and (
+                self.core.count == self.n_assem_core):
             lib.record_time_series(lib.POWER, self, self.power_cap)
             lib.record_time_series("supplyPOWER", self, int(self.power_cap))
             print("time:", self.context.time, "record 100 power")
@@ -226,18 +242,22 @@ class DepleteReactor(Facility):
             print("time:", self.context.time, "record 0 power")
 
         if (self.cycle_step > 0) or (self.core.count == self.n_assem_core):
-            self.cycle_step += 1  
-            print("time:", self.context.time, "end tock, cycle step:", self.cycle_step)
-        return 
+            self.cycle_step += 1
+            print(
+                "time:",
+                self.context.time,
+                "end tock, cycle step:",
+                self.cycle_step)
+        return
 
     def enter_notify(self):
-        super().enter_notify()       
+        super().enter_notify()
         if len(self.fuel_prefs) == 0:
-            self.fuel_prefs = [1]*len(self.fuel_incommods)
-  
+            self.fuel_prefs = [1] * len(self.fuel_incommods)
+
     def check_decommission_condition(self):
         '''
-        If the core and the spent fuel are empty, then the core can be 
+        If the core and the spent fuel are empty, then the core can be
         decommissioned.
         '''
         print("time:", self.context.time, "core count:", self.core.count)
@@ -246,92 +266,106 @@ class DepleteReactor(Facility):
         else:
             return False
 
-    def get_material_requests(self): # phase 1
+    def get_material_requests(self):  # phase 1
         '''
-        Send out bid for fuel_incommods. 
+        Send out bid for fuel_incommods.
 
-        The number of assemblies to order is the total number needed 
-        for the core less what is currently in the core plus 
-        how many need to be in the fresh fuel storage less how many 
-        exist there already. 
+        The number of assemblies to order is the total number needed
+        for the core less what is currently in the core plus
+        how many need to be in the fresh fuel storage less how many
+        exist there already.
 
-        If the reactor has a finite lifetime, calculate the number of 
-        cycles left and the number of assemblies needed for the 
-        lifetime of the reactor. Order whichever number is 
-        lower. 
-        
-        If the reactor does not need more fuel or is retired, then 
+        If the reactor has a finite lifetime, calculate the number of
+        cycles left and the number of assemblies needed for the
+        lifetime of the reactor. Order whichever number is
+        lower.
+
+        If the reactor does not need more fuel or is retired, then
         submit no bids for materials.
 
-        Create a request portfolio for each assembly needed to be ordered. 
-        Create an untracked material for each possible in commodity that 
-        can be used to meet the demand of each assembly. Set up a mutual request 
+        Create a request portfolio for each assembly needed to be ordered.
+        Create an untracked material for each possible in commodity that
+        can be used to meet the demand of each assembly. Set up a mutual request
         (logic OR) for each material that can meet a single assembly demand.
-        Apply the mass constraint of an assembly size for each assembly to 
-        order. 
+        Apply the mass constraint of an assembly size for each assembly to
+        order.
         '''
         ports = []
-        n_assem_order = self.n_assem_core - self.core.count + self.n_assem_fresh - self.fresh_fuel.count
-        print("time:", self.context.time, "request", n_assem_order, "assemblies")
+        n_assem_order = self.n_assem_core - self.core.count + \
+            self.n_assem_fresh - self.fresh_fuel.count
+        print(
+            "time:",
+            self.context.time,
+            "request",
+            n_assem_order,
+            "assemblies")
         if self.exit_time != -1:
             time_left = self.exit_time - self.context.time + 1
             time_left_cycle = self.cycle_time + self.refuel_time - self.cycle_step
-            n_cycles_left = (time_left - time_left_cycle)/(self.cycle_time + self.refuel_time)
+            n_cycles_left = (time_left - time_left_cycle) / \
+                (self.cycle_time + self.refuel_time)
             n_cycles_left = math.ceil(n_cycles_left)
-            n_need = max(0, n_cycles_left*self.n_assem_batch - self.n_assem_fresh + self.n_assem_core - self.core.count)
+            n_need = max(
+                0,
+                n_cycles_left *
+                self.n_assem_batch -
+                self.n_assem_fresh +
+                self.n_assem_core -
+                self.core.count)
             n_assem_order = min(n_assem_order, n_need)
 
         if n_assem_order == 0 or self.retired():
             return ports
 
-        for ii in range(n_assem_order): 
-            port = {}
+        for ii in range(n_assem_order):
+            port = []
             for jj in range(0, len(self.fuel_incommods)):
                 commod = self.fuel_incommods[jj]
                 pref = self.fuel_prefs[jj]
                 recipe = self.context.get_recipe(self.fuel_inrecipes[jj])
-                material = ts.Material.create_untracked(self.assem_size, recipe)
-                # the material should have the preference defined with it. 
-                #print(material.preference, pref)
+                material = ts.Material.create_untracked(
+                    self.assem_size, recipe)
+                # the material should have the preference defined with it.
+                # print(material.preference, pref)
 
-                #port.update({commod:material, "preference":pref})
-                #print(port)
-                
-                lib.record_time_series("demand"+commod, self, self.assem_size)
-                #print("updated port:", port)
-                ports.append({"commodities":{commod:material}, 
-                              "constraints":self.assem_size,
-                              'preference': pref})
+                port.append({commod: material, "preference": pref})
+                # print(port)
+
+                lib.record_time_series(
+                    "demand" + commod, self, self.assem_size)
+                # print("updated port:", port)
+
+                # ports.append({"commodities":{commod:material},"constraints":self.assem_size,'preference':pref})
+            ports.append({"commodities": port, "constraints": self.assem_size})
             # ports = {"commodities":{"fuelA":target_a, "fuelB":target_b}, "constraints":self.assem_size}
         print("time:", self.context.time, "finish get_material_requests")
-        print("request portfolio:", ports)
+        print("request portfolio:", ports, len(ports))
         return ports
-    
 
-    def get_material_bids(self, requests): # phase 2
+    def get_material_bids(self, requests):  # phase 2
         '''
         Read bids for fuel_outcommods and return bid portfolio.
 
-        If the unique_commods_ string is empty, add the names of 
+        If the unique_commods_ string is empty, add the names of
         the fuel out commodities.
 
-        For each of the items in the unique commodities list, 
-        if there are no requests for a given commodity name, then 
-        continue to the next commodity. Get the recipe for 
+        For each of the items in the unique commodities list,
+        if there are no requests for a given commodity name, then
+        continue to the next commodity. Get the recipe for
         each commodity requested.
 
-        Looking at the composition for each commodity, 
-        if there is no composition, then move to the next commodity. 
+        Looking at the composition for each commodity,
+        if there is no composition, then move to the next commodity.
 
-        For each request of each commodity, sum the total request 
-        for the commodity. Then create a bid for each request of 
+        For each request of each commodity, sum the total request
+        for the commodity. Then create a bid for each request of
         each commodity.
 
-        For each material composition sum to total mass of 
+        For each material composition sum to total mass of
         the composition.
 
         Add a constraint of the total quantity of the commodity available.
-        Create a bid portfolio for each request that can be met. 
+        Create a bid portfolio for each request that can be met.
         '''
         print("time:", self.context.time, "start get material_bids")
         got_mats = False
@@ -347,17 +381,22 @@ class DepleteReactor(Facility):
             if len(all_mats) == 0:
                 tot_qty = 0
                 continue
-            if commod in all_mats: 
+            if commod in all_mats:
                 mats = [all_mats[commod]]
-                
+
             else:
                 mats = []
-            print("time:", self.context.time, "mats to trade matching request commod:", mats)
+            print(
+                "time:",
+                self.context.time,
+                "mats to trade matching request commod:",
+                mats)
             if len(mats) == 0:
-                continue 
+                continue
 
-            recipe_comp = self.context.get_recipe(self.fuel_outrecipes[commod_index])
-    
+            recipe_comp = self.context.get_recipe(
+                self.fuel_outrecipes[commod_index])
+
             for req in reqs:
                 tot_bid = 0
                 for jj in range(len(mats)):
@@ -365,33 +404,38 @@ class DepleteReactor(Facility):
                     qty = min(req.target.quantity, self.assem_size)
                     mat = ts.Material.create_untracked(qty, recipe_comp)
                     for kk in range(self.spent_fuel.count):
-                        bids.append({'request':req,'offer':mat})
+                        bids.append({'request': req, 'offer': mat})
                     if tot_bid >= req.target.quantity:
-                         break
+                        break
             tot_qty = 0
             for mat in mats:
                 tot_qty += mat.quantity
         if len(bids) == 0:
-            return 
+            return
 
-        port = {'bids':bids}
+        port = {'bids': bids}
         print("time:", self.context.time, "portfolio:", port)
         print("time:", self.context.time, "respond", len(bids), "assemblies")
-        return port     
+        return port
 
-    def get_material_trades(self, trades): #phase 5.1
+    def get_material_trades(self, trades):  # phase 5.1
         '''
         Trade away material in the spent_fuel material buffer.
 
         Pull out the material from spent fuel inventory
-        For each trade, get the commodity name, get the 
+        For each trade, get the commodity name, get the
         composition of the trade.
 
-        Then trade the materials from the spent fuel inventory. 
+        Then trade the materials from the spent fuel inventory.
         '''
         responses = {}
         mats = self.pop_spent()
-        print("time:", self.context.time, "trade away", len(trades), "assemblies")
+        print(
+            "time:",
+            self.context.time,
+            "trade away",
+            len(trades),
+            "assemblies")
         for ii in range(len(trades)):
             print("time:", self.context.time, "number of trades:", len(trades))
             commodity = trades[ii].request.commodity
@@ -400,32 +444,33 @@ class DepleteReactor(Facility):
             self.resource_indexes.pop(mat.obj_id)
         self.push_spent(mats)
 
-        return responses 
+        return responses
 
-    def accept_material_trades(self, responses): # phase 5.2
+    def accept_material_trades(self, responses):  # phase 5.2
         '''
         Accept bid for fuel_incommods
 
-        The number of assemblies to be loaded is the minimum 
-        of the number of responses or the number of 
-        assemblies the core is missing (full core minus how many 
-        assemblies are present). If the number of assemblies to 
+        The number of assemblies to be loaded is the minimum
+        of the number of responses or the number of
+        assemblies the core is missing (full core minus how many
+        assemblies are present). If the number of assemblies to
         load is greater than 0, then record this number.
 
-        For each trade in the responses, get the commodity requested 
-        in the trade and reset the index. 
+        For each trade in the responses, get the commodity requested
+        in the trade and reset the index.
 
-        If the core is not full, the put the material in the core. 
-        If the core is full, the put the material in the fresh 
-        fuel inventory. 
+        If the core is not full, the put the material in the core.
+        If the core is full, the put the material in the fresh
+        fuel inventory.
 
         '''
         print("time:", self.context.time, "responses:", responses)
-        n_load = len(responses) #min(len(responses), self.n_assem_core - self.core.count)
+        # min(len(responses), self.n_assem_core - self.core.count)
+        n_load = len(responses)
         print("time:", self.context.time, "accept", n_load, "assemblies")
         if n_load > 0:
             ss = str(n_load) + " assemblies"
-            #self.record("LOAD", ss)
+            # self.record("LOAD", ss)
         for trade in responses:
             print(trade.request.commodity, trade.request.preference, trade.amt)
             commodity = trade.request.commodity
@@ -437,7 +482,7 @@ class DepleteReactor(Facility):
                 self.fresh_fuel.push(material)
 
         print("core:", self.core.count, "fresh:", self.fresh_fuel.count)
-        return 
+        return
 
     def retired(self):
         '''
@@ -453,70 +498,71 @@ class DepleteReactor(Facility):
         '''
         npop = min(self.n_assem_batch, self.core.count)
         if (self.n_assem_spent - self.spent_fuel.count) < npop:
-            #self.record("DISCHARGE", "failed")
+            # self.record("DISCHARGE", "failed")
             return False
 
         ss = str(npop) + " assemblies"
-        #self.record("DISCHARGE", ss)
+        # self.record("DISCHARGE", ss)
         print("time:", self.context.time, "discharge", ss)
 
         core_pop = self.core.pop_n(npop)
         for ii in range(len(core_pop)):
             self.spent_fuel.push(core_pop[ii])
         tot_spent = 0
-        
+
         for ii in range(len(self.fuel_outcommods)):
             spent_mats = self.peek_spent()
             if self.fuel_outcommods[ii] in spent_mats:
                 mats = spent_mats[self.fuel_outcommods[ii]]
                 tot_spent += mats.quantity
-                lib.record_time_series("supply"+self.fuel_outcommods[ii], self, tot_spent)
+                lib.record_time_series(
+                    "supply" + self.fuel_outcommods[ii], self, tot_spent)
 
         return True
 
     def load(self):
         '''
-        Determine number of assemblies to load, either the 
-        number of assemblies needed for the core less the number 
-        already in the core or the number held by the 
-        fresh fuel inventory. If no assemblies are needed, then 
-        return. 
+        Determine number of assemblies to load, either the
+        number of assemblies needed for the core less the number
+        already in the core or the number held by the
+        fresh fuel inventory. If no assemblies are needed, then
+        return.
 
-        Record the number of assemblies that are to be loaded, then move 
-        them from the fresh fuel inventory to the core inventory. 
+        Record the number of assemblies that are to be loaded, then move
+        them from the fresh fuel inventory to the core inventory.
         '''
-        n = min((self.n_assem_core-self.core.count), self.fresh_fuel.count)
+        n = min((self.n_assem_core - self.core.count), self.fresh_fuel.count)
         print("time:", self.context.time, "load", n, "assemblies")
         if n == 0:
             return
         ss = str(n) + " assemblies"
-        #self.record("LOAD", ss)
+        # self.record("LOAD", ss)
         assemblies = self.fresh_fuel.pop_n(n)
         for ii in range(len(assemblies)):
             self.core.push(assemblies[ii])
-        return 
+        return
 
     def transmute(self, n_assem):
         '''
-        Get the material composition of the minimum of the 
-        number of assemblies specified or the number of 
-        assemblies in the core. 
+        Get the material composition of the minimum of the
+        number of assemblies specified or the number of
+        assemblies in the core.
 
-        If there are more assemblies in the core than what will 
-        be removed, then rotate the untransmuted materials to the back 
+        If there are more assemblies in the core than what will
+        be removed, then rotate the untransmuted materials to the back
         of the buffer.
 
         Record the number of assemblies to be transmuted. Transmute the fuel
-        by changing the recipe of the material to that of the 
+        by changing the recipe of the material to that of the
         fuel_outrecipes
 
         There seem to be two Transmute functions in the cycamore reactor?
         '''
         old = self.core.pop_n(min(n_assem, self.core.count))
         for ii in range(len(old)):
-            self.core.push(old[ii]) 
+            self.core.push(old[ii])
         ss = str(len(old)) + " assemblies"
-        #self.record("TRANSMUTE", ss)
+        # self.record("TRANSMUTE", ss)
         print("time:", self.context.time, "transmute", ss)
         for ii in range(len(old)):
             print("call OpenMC")
@@ -524,53 +570,53 @@ class DepleteReactor(Facility):
 
     def record(self, event, val):
         '''
-        Record a reactor event to the output database with the 
+        Record a reactor event to the output database with the
         given name and note val
 
         Parameters:
         -----------
-        event: str 
+        event: str
             name of event
         val: str
             value of event
         '''
-        events = self.context.new_datum("ReactorEvents") # creates tables with name ReactorEvents
+        events = self.context.new_datum(
+            "ReactorEvents")  # creates tables with name ReactorEvents
         datum = lib.Datum("Event")
         lib.Datum.add_val(datum, "Event", event)
         events.add_val("Value", val)
         events.record()
         return
 
-        
     def index_res(self, material, incommod):
         '''
-        For the name of any item in the fuel in_commods list 
-        match the name of the commodity given, then 
+        For the name of any item in the fuel in_commods list
+        match the name of the commodity given, then
         the object Id of the material.
 
-        If the name of the given commodity isn't in the 
-        fuel in_commods list, then return an error. 
+        If the name of the given commodity isn't in the
+        fuel in_commods list, then return an error.
         '''
         try:
             for ii in range(len(self.fuel_incommods)):
                 if self.fuel_incommods[ii] == incommod:
-                    self.resource_indexes[material.obj_id] = ii 
+                    self.resource_indexes[material.obj_id] = ii
                     return
-        except:
-            raise ValueError (
-                "openmcyclus.DepleteReactor:DepleteReactor received "\
+        except BaseException:
+            raise ValueError(
+                "openmcyclus.DepleteReactor:DepleteReactor received "
                 "unsupported incommod material"
             )
 
     def pop_spent(self):
         '''
-        For each assembly in the spent fuel inventory, 
-        get the commodity name of it, and push the material 
+        For each assembly in the spent fuel inventory,
+        get the commodity name of it, and push the material
         back to the spent fuel inventory (??).
 
-        Then reverse the order of the material in the 
-        mapped materials to put the oldest assemblies 
-        first and make sure they get traded away first. 
+        Then reverse the order of the material in the
+        mapped materials to put the oldest assemblies
+        first and make sure they get traded away first.
         '''
         mats = self.spent_fuel.pop_n(self.spent_fuel.count)
         mapped = {}
@@ -591,11 +637,11 @@ class DepleteReactor(Facility):
             leftover[commod].reverse
             for material in leftover[commod]:
                 self.spent_fuel.push(material)
-        return 
+        return
 
     def peek_spent(self):
         '''
-        
+
         '''
         mapped = {}
         if self.spent_fuel.count > 0:
@@ -603,12 +649,12 @@ class DepleteReactor(Facility):
             for ii in range(len(mats)):
                 self.spent_fuel.push(mats[ii])
                 commod = self.get_commod(mats[ii], 'out')
-                mapped[commod] = mats[ii] 
+                mapped[commod] = mats[ii]
         return mapped
 
     def get_commod(self, material, flow):
         '''
-        Get the index in fuel_incommods or fuel_outcommods 
+        Get the index in fuel_incommods or fuel_outcommods
         corresponding to the object id of a material
         '''
         ii = self.resource_indexes[material.obj_id]
@@ -616,10 +662,10 @@ class DepleteReactor(Facility):
             return self.fuel_incommods[ii]
         elif flow == 'out':
             return self.fuel_outcommods[ii]
-    
+
     def get_recipe(self, material, flow):
         '''
-        Get the index in fuel_inrecipes or fuel_outrecipes 
+        Get the index in fuel_inrecipes or fuel_outrecipes
         corresponding to the object id of a material
         '''
         ii = self.resource_indexes[material.obj_id]
@@ -627,10 +673,10 @@ class DepleteReactor(Facility):
             return self.fuel_inrecipes[ii]
         elif flow == 'out':
             return self.fuel_outrecipes[ii]
-    
+
     def get_pref(self, material):
         '''
-        Get the index in fuel_prefs 
+        Get the index in fuel_prefs
         corresponding to the object id of a material
         '''
         ii = self.resource_indexes[material.obj_id]

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -291,15 +291,22 @@ class DepleteReactor(Facility):
                 pref = self.fuel_prefs[jj]
                 recipe = self.context.get_recipe(self.fuel_inrecipes[jj])
                 material = ts.Material.create_untracked(self.assem_size, recipe)
-                port.update({commod:material})
+                # the material should have the preference defined with it. 
+                #print(material.preference, pref)
+
+                #port.update({commod:material, "preference":pref})
+                #print(port)
                 
                 lib.record_time_series("demand"+commod, self, self.assem_size)
                 #print("updated port:", port)
-            ports.append({"commodities":port, "constraints":self.assem_size})
+                ports.append({"commodities":{commod:material}, 
+                              "constraints":self.assem_size,
+                              'preference': pref})
             # ports = {"commodities":{"fuelA":target_a, "fuelB":target_b}, "constraints":self.assem_size}
         print("time:", self.context.time, "finish get_material_requests")
-        print("request portfolio:", ports, len(ports))
+        print("request portfolio:", ports)
         return ports
+    
 
     def get_material_bids(self, requests): # phase 2
         '''
@@ -370,7 +377,7 @@ class DepleteReactor(Facility):
         port = {'bids':bids}
         print("time:", self.context.time, "portfolio:", port)
         print("time:", self.context.time, "respond", len(bids), "assemblies")
-        return port
+        return port     
 
     def get_material_trades(self, trades): #phase 5.1
         '''

--- a/tests/integration_tests/test_depletereactor.py
+++ b/tests/integration_tests/test_depletereactor.py
@@ -61,13 +61,14 @@ class TestDepleteReactor(unittest.TestCase):
         spec: str
             value to find in a column
         a: table
-            database table to searc
+            database table to search
         spec_col: str
             Name of column to search
         id_col: str
             column name to search
 
         Returns:
+        --------
         array
         '''
 

--- a/tests/integration_tests/test_depletereactor.py
+++ b/tests/integration_tests/test_depletereactor.py
@@ -157,9 +157,9 @@ class TestComplex(TestDepleteReactor):
         unique, counts = np.unique(commodities, return_counts=True)
         count_dict = dict(zip(unique,counts))
         assert len(tbl) == 12
-        assert 'uox' not in unique
-        assert count_dict['mox'] == 6
-        assert 'spent_uox' not in unique
+        assert count_dict['uox'] == 2
+        assert count_dict['mox'] == 4
+        assert count_dict['spent_uox'] == 2
         assert count_dict['spent_mox'] == 6
         assert all(times == [3,3,3,5,5,8,8,11,11,13,13,13])
 

--- a/tests/integration_tests/test_depletereactor.py
+++ b/tests/integration_tests/test_depletereactor.py
@@ -161,7 +161,7 @@ class TestComplex(TestDepleteReactor):
         assert count_dict['uox'] == 2
         assert count_dict['mox'] == 4
         assert count_dict['spent_uox'] == 2
-        assert count_dict['spent_mox'] == 6
+        assert count_dict['spent_mox'] == 4
         assert all(times == [3,3,3,5,5,8,8,11,11,13,13,13])
 
     def test_resources(self):


### PR DESCRIPTION
This PR has two primary additions:
- Input commodity preferences are added (new feature)
- Transaction issues are fixed when multiple commodities are requested (a bug fix, for a bug discovered while adding the feature)

Test and test-related files have been updated to test the new functionality and ensure the bug is fixed. There are two tests that are failing because of a bug with resource IDs for the spent fuel. This bug (Issue #9) will be fixed in a later PR. The 2 tests regarding transactions are both passing, and those are the tests for the feature and bug fix in this PR. 
