### PR TITLE
Remove nose from the testing environment

### DIFF
--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -26,7 +26,7 @@ jobs:
           mamba env update -n openmcyclus-env -f environment.yml
 
       - name: Install pytest
-        run: conda install -y pytest nose
+        run: conda install -y pytest
 
       - name: Build OpenMC 
         run: |

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,5 @@ channels:
   - defaults
 dependencies:
   - numpy
-  - nose
   - pytest
   - pip

--- a/tests/integration_tests/helper.py
+++ b/tests/integration_tests/helper.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 from hashlib import sha1
 import numpy as np
-from nose.tools import assert_equal
 
 
 CYCLUS_HAS_COIN = None
@@ -84,8 +83,7 @@ def check_cmd(args, cwd, holdsrtn):
             f.seek(0)
             print("STDOUT + STDERR:\n\n" + f.read().decode())
     holdsrtn[0] = return_code
-    assert_equal(return_code, 0)
-
+    assert return_code == 0
 
 def cyclus_has_coin():
     global CYCLUS_HAS_COIN


### PR DESCRIPTION
This PR removes the use of nose from the testing suite and the CI environment. This is done to make the testing rely only on pytest instead of pytest and nose. 