### PR TITLE
Add call to the OpenMC Depletion Solver

### DIFF
--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -2,10 +2,10 @@ name: test-openmcyclus
 on: [push, pull_request]
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     container:
-      image: docker://cyclus/cycamore:latest
+      image: cyclus/cycamore
     steps:
       - uses: actions/checkout@v3
       - name: Setup Conda
@@ -25,10 +25,13 @@ jobs:
         run: |
           mamba env update -n openmcyclus-env -f environment.yml
 
+      - name: Install pytest
+        run: conda install -y pytest nose
+
       - name: Build OpenMC 
         run: |
           mamba install openmc
-          
+
       - name: Install OpenMC cross section library
         run: echo "OPENMC_CROSS_SECTIONS=cross_sections.xml" >> $GITHUB_ENV
 

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -55,3 +55,5 @@ jobs:
         run: |
           pytest 
 
+FWAk8hnxPUNDeep!
+

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -23,11 +23,12 @@ jobs:
       
       - name: Update Environment
         run: |
-          conda install -y pytest numpy nose
+          mamba env update -n openmcyclus-env -f environment.yml
 
       - name: Build OpenMC 
         run: |
           mamba install openmc
+          
       - name: Install OpenMC cross section library
         run: echo "OPENMC_CROSS_SECTIONS=cross_sections.xml" >> $GITHUB_ENV
 

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -8,7 +8,15 @@ jobs:
       image: docker://cyclus/cycamore:latest
     steps:
       - uses: actions/checkout@v3
-        
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: openmcyclus-env
+          environment-file: environment.yml
+          use-mamba: true  
+
       - name: Conda config
         run: |
           conda config --env --set pip_interop_enabled True 
@@ -16,6 +24,13 @@ jobs:
       - name: Update Environment
         run: |
           conda install -y pytest numpy nose
+          mamba env update -n openmcyclus-env -f environment.yml
+
+      - name: Build OpenMC 
+        run: |
+          mamba install openmc
+      - name: Install OpenMC cross section library
+        run: echo "OPENMC_CROSS_SECTIONS=cross_sections.xml" >> $GITHUB_ENV
 
       - name: Install OpenMCyclus
         run: |
@@ -23,4 +38,4 @@ jobs:
       
       - name: Run Tests
         run: |
-          pytest --ignore tests/unit_tests
+          pytest 

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -39,6 +39,11 @@ jobs:
         run: |
           pip install .
       
+      - name: Check environment 
+        run: |
+          conda list
+          pip list
+          
       - name: Run Tests
         run: |
           pytest 

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Run Tests
         run: |
-          pytest 
+          pytest --ignore tests/unit_tests

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -42,5 +42,6 @@ jobs:
       
       - name: Run Tests
         uses: docker://cyclus/cycamore
-        run: |
-          pytest 
+        with:
+          image: cyclus/cycamore
+          run: pytest 

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -11,11 +11,8 @@ jobs:
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           activate-environment: openmcyclus-env
-          environment-file: environment.yml
-          use-mamba: true  
 
       - name: Conda config
         run: |
@@ -27,12 +24,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          conda install -y python=3.7 cyclus cycamore hdf5 coincbc=2.9 gettext jinja2 libxml2 libxmlpp nose pytest pcre websockets xz libgfortran4 cython matplotlib notebook nb_conda_kernels pandas requests entrypoints pyyaml vtk coverage pytest-cov colorama 
+          conda install -y python=3.7 cyclus cycamore hdf5 coincbc=2.9 libxml2 libxmlpp nose pytest pcre websockets xz libgfortran4 cython gcc_linux-64=12.2 gxx_linux-64=12.2 cmake make
           HDF5_DIR=$CONDA_PREFIX && pip install h5py
-
-      - name: Install OpenMC cross section library
-        run: $GITHUB_WORKSPACE/openmc-xs.bash
-      
+   
       - name: OpenMC dependencies
         run: |
           sudo apt -y update
@@ -63,5 +57,5 @@ jobs:
 
       - name: Run Tests
         run: |
-          pytest --ignore tests/unit_tests
+          pytest 
 

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          conda install -y python=3.7 cyclus cycamore hdf5 nose pytest libgfortran4 gcc_linux-64=12.2 gxx_linux-64=12.2 cmake make
+          conda install -y python=3.7 cyclus cycamore hdf5 coincbc=2.9 gettext jinja2 libxml2 libxmlpp nose pytest pcre websockets xz libgfortran4 cython matplotlib notebook nb_conda_kernels pandas requests entrypoints pyyaml vtk coverage pytest-cov colorama gcc_linux-64=12.2 gxx_linux-64=12.2 libpng cmake make
           HDF5_DIR=$CONDA_PREFIX && pip install h5py
    
       - name: OpenMC dependencies

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          conda install -y python=3.7 cyclus cycamore hdf5 coincbc=2.9 gettext jinja2 libxml2 libxmlpp nose pytest pcre websockets xz libgfortran4 cython matplotlib notebook nb_conda_kernels pandas requests entrypoints pyyaml vtk coverage pytest-cov colorama gcc_linux-64=12.2 gxx_linux-64=12.2 libpng cmake make
+          conda install -y python=3.7 cyclus cycamore 
           HDF5_DIR=$CONDA_PREFIX && pip install h5py
    
       - name: OpenMC dependencies

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -25,12 +25,30 @@ jobs:
         run: |
           mamba env update -n openmcyclus-env -f environment.yml
 
-      - name: Install pytest
-        run: conda install -y pytest nose
-
-      - name: Build OpenMC 
+      - name: Install dependencies
         run: |
-          mamba install openmc
+          conda install -y python=3.7 cyclus cycamore hdf5 coincbc=2.9 gettext jinja2 libxml2 libxmlpp nose pytest pcre websockets xz libgfortran4 cython matplotlib notebook nb_conda_kernels pandas requests entrypoints pyyaml vtk coverage pytest-cov colorama 
+          HDF5_DIR=$CONDA_PREFIX && pip install h5py
+
+      - name: Install OpenMC cross section library
+        run: $GITHUB_WORKSPACE/openmc-xs.bash
+      
+      - name: OpenMC dependencies
+        run: |
+          sudo apt -y update
+          sudo apt install -y libhdf5-dev
+
+      - name: Download OpenMC
+        uses: actions/checkout@v3
+        with: 
+          repository: openmc-dev/openmc
+          path: openmc
+          submodules: recursive
+
+      - name: Build OpenMC from source
+        run: |
+          run: build-openmc.sh
+
 
       - name: Install OpenMC cross section library
         run: echo "OPENMC_CROSS_SECTIONS=cross_sections.xml" >> $GITHUB_ENV
@@ -46,3 +64,4 @@ jobs:
       - name: Run Tests
         run: |
           pytest --ignore tests/unit_tests
+

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          conda install -y python=3.7 cyclus cycamore hdf5 coincbc=2.9 libxml2 libxmlpp nose pytest pcre websockets xz libgfortran4 cython gcc_linux-64=12.2 gxx_linux-64=12.2 cmake make
+          conda install -y python=3.7 cyclus cycamore hdf5 nose pytest ibgfortran4 gcc_linux-64=12.2 gxx_linux-64=12.2 cmake make
           HDF5_DIR=$CONDA_PREFIX && pip install h5py
    
       - name: OpenMC dependencies

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -5,7 +5,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     container: 
-      image: cyclus:cycamore
+      image: cyclus/cycamore:latest
     defaults:
       run: 
         shell: bash -l {0}

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -17,10 +17,6 @@ jobs:
       - name: Conda config
         run: |
           conda config --env --set pip_interop_enabled True 
-      
-      - name: Update Environment
-        run: |
-          mamba env update -n openmcyclus-env -f environment.yml
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -57,6 +57,3 @@ jobs:
       - name: Run Tests
         run: |
           pytest 
-
-FWAk8hnxPUNDeep!
-

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Update Environment
         run: |
           conda install -y pytest numpy nose
-          mamba env update -n openmcyclus-env -f environment.yml
 
       - name: Build OpenMC 
         run: |

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -41,9 +41,8 @@ jobs:
       
       - name: Check environment 
         run: |
-          conda list
-          pip list
-          
+          pip install pytest
+
       - name: Run Tests
         run: |
           pytest 

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -41,5 +41,6 @@ jobs:
           pip install .
       
       - name: Run Tests
+        uses: docker://cyclus/cycamore
         run: |
           pytest 

--- a/.github/workflows/test-openmcyclus.yml
+++ b/.github/workflows/test-openmcyclus.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          conda install -y python=3.7 cyclus cycamore hdf5 nose pytest ibgfortran4 gcc_linux-64=12.2 gxx_linux-64=12.2 cmake make
+          conda install -y python=3.7 cyclus cycamore hdf5 nose pytest libgfortran4 gcc_linux-64=12.2 gxx_linux-64=12.2 cmake make
           HDF5_DIR=$CONDA_PREFIX && pip install h5py
    
       - name: OpenMC dependencies

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ library. The input structure is:
       <fuel_outrecipes>
         <val>string</val> 
         ...
-        <val>string<v/al>
+        <val>string</val>
       </fuel_outrecipes>
       <assem_size>double</assem_size>
       <cycle_time>int</cycle_time>

--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ and their required dependencies. It is recommended to install Cyclus from source
 then install OpenMC in a separate conda environment as their python dependencies 
 clash when both are installed via conda in the same environment.
 
+Current installation:
+- install all cyclus dependencies, except cython, and use python 3.7
+- install mamba
+- install openmc
+- install openmcyclus, run depletion.py unit tests
+- install cython 0.289 via conda
+- build cyclus from source 
+- needed to uninstall and reinstall libxml2
+- need to install libxmlpp version 2.40, glibmm = 2.52, libsigcpp=2.10
+
+In secondary envrionment:
+- install all cyclus dependencies (as written in github)
+
+Whatever environment you first build in, cyclus points to those 
+python packages
+
 ### Running
 This archetype assumes that you have a defined reactor model in OpenMC (``.xml``) 
 files and the 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,34 @@ Current installation:
 - install pytest
 - install mamba
 - install openmc
-- install openmcyclus, run depletion.py unit tests
-- install cython 0.289 via conda
-- build cyclus from source 
+- build cyclus from source -- din't work
+- install cyclus/cycamore from conda
+
+
+
+
+Conda isntallation: 
+conda install -y python=3.7 cyclus cycamore hdf5 sqlite bzip2 coincbc=2.9 gettext jinja2 libxml2 libxmlpp nose pytest pcre setuptools websockets xz libgfortran4
+conda install   - scipy
+  - cython
+  - matplotlib
+  - notebook
+  - nb_conda_kernels
+  - pandas
+  - uncertainties
+  - lxml
+  - pytest
+  - requests
+  - entrypoints
+  - pyyaml
+  - vtk
+  - coverage
+  - pytest-cov
+  - colorama
+
+
+
+
 - needed to uninstall and reinstall libxml2
 - need to install libxmlpp version 2.40, glibmm = 2.52, libsigcpp=2.10,
 python 3.7, unspecify cython

--- a/README.md
+++ b/README.md
@@ -68,35 +68,35 @@ library. The input structure is:
       <fuel_incommods>
         <val>string</val>
         ...
-        <val>string<val>
+        <val>string</val>
       </fuel_incommods>
       <fuel_prefs>
         <val>double</val>
         ...
-        <val>double<val>
+        <val>double</val>
       </fuel_prefs>
       <fuel_outcommods>
         <val>string</val>
         ...
-        <val>string<val>
+        <val>string</val>
       </fuel_outcommods>
       <fuel_inrecipes>
         <val>string</val> 
         ...
-        <val>string<val>
+        <val>string</val>
       </fuel_inrecipes>
       <fuel_outrecipes>
         <val>string</val> 
         ...
-        <val>string<val>
+        <val>string<v/al>
       </fuel_outrecipes>
-      <assem_size>double<assem_size>
+      <assem_size>double</assem_size>
       <cycle_time>int</cycle_time>
       <refuel_time>int</refuel_time>
       <n_assem_core>int</n_assem_core>
       <n_assem_batch>int</n_assem_batch>
       <power_cap>double</power_cap>
-    </DeployReactor>
+    </DepleteReactor>
 
 The `fuel_prefs`, `fuel_inrecipes`, and `fuel_outrecipes` state variables are optional.
 But if included, `fuel_prefs` and `fuel_inrecipes` must be equal in length to 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ clash when both are installed via conda in the same environment.
 
 conda install -y python=3.7 cyclus cycamore hdf5 coincbc=2.9 gettext jinja2 libxml2 libxmlpp nose pytest pcre websockets xz libgfortran4 cython matplotlib notebook nb_conda_kernels pandas requests entrypoints pyyaml vtk coverage pytest-cov colorama gcc_linux-64=12.2 gxx_linux-64=12.2 libpng cmake make
 
+HDF5_DIR=$CONDA_PREFIX \
 pip install --upgrade-strategy only-if-needed --no-binary=h5py h5py
+
 
 git clone --recurse-submodules https://github.com/openmc-dev/openmc.git
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 Repository of [Cyclus](https://fuelcycle.org/) archetypes to couple Cyclus with [OpenMC](https://docs.openmc.org/en/develop/pythonapi/generated/openmc.run.html)
 
 ## Installation 
-To install this archetype library run ``pip install .``. 
-To run tests: ``pytest`` from the main directory.
+
 
 ### Dependencies
 You will need to have [Cyclus](www.github.com/cyclus/cyclus), [OpenMC](https://docs.openmc.org).
@@ -13,48 +12,30 @@ and their required dependencies. It is recommended to install Cyclus from source
 then install OpenMC in a separate conda environment as their python dependencies 
 clash when both are installed via conda in the same environment.
 
-Current installation:
-- install all cyclus dependencies, see versions below
-- install pytest
-- install mamba
-- install openmc
-- build cyclus from source -- din't work
-- install cyclus/cycamore from conda
+conda install -y python=3.7 cyclus cycamore hdf5 coincbc=2.9 gettext jinja2 libxml2 libxmlpp nose pytest pcre websockets xz libgfortran4 cython matplotlib notebook nb_conda_kernels pandas requests entrypoints pyyaml vtk coverage pytest-cov colorama gcc_linux-64=12.2 gxx_linux-64=12.2 libpng cmake make
+
+pip install --upgrade-strategy only-if-needed --no-binary=h5py h5py
+
+git clone --recurse-submodules https://github.com/openmc-dev/openmc.git
+
+cd openmc/
+
+mkdir build && cd build
+
+cmake ..
+
+make
+
+sudo make install
+
+cd ../
+
+pip install .
 
 
-
-
-Conda isntallation: 
-conda install -y python=3.7 cyclus cycamore hdf5 sqlite bzip2 coincbc=2.9 gettext jinja2 libxml2 libxmlpp nose pytest pcre setuptools websockets xz libgfortran4
-conda install   - scipy
-  - cython
-  - matplotlib
-  - notebook
-  - nb_conda_kernels
-  - pandas
-  - uncertainties
-  - lxml
-  - pytest
-  - requests
-  - entrypoints
-  - pyyaml
-  - vtk
-  - coverage
-  - pytest-cov
-  - colorama
-
-
-
-
-- needed to uninstall and reinstall libxml2
-- need to install libxmlpp version 2.40, glibmm = 2.52, libsigcpp=2.10,
-python 3.7, unspecify cython
-
-In secondary envrionment:
-- install all cyclus dependencies (as written in github)
-
-Whatever environment you first build in, cyclus points to those 
-python packages
+### Install OpenMCyclus
+To install this archetype library run ``pip install .``. 
+To run tests: ``pytest`` from the main directory.
 
 ### Running
 This archetype assumes that you have a defined reactor model in OpenMC (``.xml``) 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,16 @@ then install OpenMC in a separate conda environment as their python dependencies
 clash when both are installed via conda in the same environment.
 
 Current installation:
-- install all cyclus dependencies, except cython, and use python 3.7
+- install all cyclus dependencies, see versions below
+- install pytest
 - install mamba
 - install openmc
 - install openmcyclus, run depletion.py unit tests
 - install cython 0.289 via conda
 - build cyclus from source 
 - needed to uninstall and reinstall libxml2
-- need to install libxmlpp version 2.40, glibmm = 2.52, libsigcpp=2.10
+- need to install libxmlpp version 2.40, glibmm = 2.52, libsigcpp=2.10,
+python 3.7, unspecify cython
 
 In secondary envrionment:
 - install all cyclus dependencies (as written in github)

--- a/README.md
+++ b/README.md
@@ -8,18 +8,26 @@ Repository of [Cyclus](https://fuelcycle.org/) archetypes to couple Cyclus with 
 
 ### Dependencies
 You will need to have [Cyclus](www.github.com/cyclus/cyclus), [OpenMC](https://docs.openmc.org).
-and their required dependencies. It is recommended to install Cyclus from source,
-then install OpenMC in a separate conda environment as their python dependencies 
-clash when both are installed via conda in the same environment.
+and their required dependencies. It is recommended to install each of these from source. 
 
-conda install -y python=3.7 cyclus cycamore hdf5 coincbc=2.9 gettext jinja2 libxml2 libxmlpp nose pytest pcre websockets xz libgfortran4 cython matplotlib notebook nb_conda_kernels pandas requests entrypoints pyyaml vtk coverage pytest-cov colorama gcc_linux-64=12.2 gxx_linux-64=12.2 libpng cmake make
+```
+conda install -y openssh gxx_linux-64=12.2 gcc_linux-64=12.2 cmake make docker-pycreds git xo python-json-logger glib libxml2 libxmlpp libblas libcblas liblapack pkg-config coincbc boost-cpp sqlite pcre gettext bzip2 xz setuptools pytest pytables pandas jinja2 cython websockets pprintpp hdf5=1.12.2 notebook nb_conda_kernels requests entrypoints pyyaml vtk coverage pytest-cov colorama libpng uncertainties lxml scipy
+
+
 
 HDF5_DIR=$CONDA_PREFIX \
 pip install --upgrade-strategy only-if-needed --no-binary=h5py h5py
 
+git clone https://github.com/abachma2/cyclus.git
 
+cd cyclus
+
+git checkout 2022-05-maintenance
+
+python install.py
+
+cd ../
 git clone --recurse-submodules https://github.com/openmc-dev/openmc.git
-
 cd openmc/
 
 mkdir build && cd build
@@ -33,13 +41,17 @@ sudo make install
 cd ../
 
 pip install .
-
+```
 
 ### Install OpenMCyclus
-To install this archetype library run ``pip install .``. 
-To run tests: ``pytest`` from the main directory.
+Clone the repository:
 
-### Running
+git clone https://github.com/arfc/openmcyclus.git 
+
+To install this archetype library run ``pip install .`` from the top level of the 
+directory. To run tests: ``pytest`` from the main directory.
+
+## Running
 This archetype assumes that you have a defined reactor model in OpenMC (``.xml``) 
 files and the 
 required microscopic cross sections (``.csv`` file) for the model. The 
@@ -86,11 +98,13 @@ library. The input structure is:
       <power_cap>double</power_cap>
     </DeployReactor>
 
-The `fuel_prefs`, `fuel_inrecipes` and `fuel_outrecipes` state variables are optional, but 
-must be of equal length to the `fuel_incommods` or `fuel_outcommods`.
+The `fuel_prefs`, `fuel_inrecipes`, and `fuel_outrecipes` state variables are optional.
+But if included, `fuel_prefs` and `fuel_inrecipes` must be equal in length to 
+`fuel_incommods` and `fuel_outrecipes` must be equal in length to `fuel_outcommods`. 
 
 
 ### Outputs
 The compositions for the spent fuel are saved to an ``.xml`` file named 
 ``prototype_fuel.xml`` in which ``prototype`` is the prototype name in 
-the Cyclus simulation
+the Cyclus simulation. The results of the simulation wil be written to `cyclus.sqlite`
+or the file name provided when Cyclus was called. 

--- a/examples/complex.xml
+++ b/examples/complex.xml
@@ -104,6 +104,8 @@
             <n_assem_core>3</n_assem_core>
             <n_assem_batch>1</n_assem_batch>
             <power_cap>100</power_cap>
+            <model_path>/home/abachmann/openmcyclus/tests/</model_path>
+            <chain_file>chain_endfb71_pwr.xml</chain_file>
           </DepleteReactor>
         </config>
     </facility>

--- a/examples/simple.xml
+++ b/examples/simple.xml
@@ -69,6 +69,8 @@
             <n_assem_core>3</n_assem_core>
             <n_assem_batch>1</n_assem_batch>
             <power_cap>100</power_cap>
+            <model_path>/home/abachmann/openmcyclus/tests/</model_path>
+            <chain_file>chain_endfb71_pwr.xml</chain_file>
           </DepleteReactor>
         </config>
     </facility>

--- a/openmc-xs.bash
+++ b/openmc-xs.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+
+wget -q -O - https://anl.box.com/shared/static/9igk353zpy8fn9ttvtrqgzvw1vtejoz6.xz | tar -C $HOME -xJ
+

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -2,7 +2,7 @@ from cyclus.agents import Facility
 from cyclus import lib
 import cyclus.typesystem as ts
 import math
-from openmcyclus.depletion import Depletion
+#from openmcyclus.depletion import Depletion
 
 class DepleteReactor(Facility):
     '''

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -2,7 +2,7 @@ from cyclus.agents import Facility
 from cyclus import lib
 import cyclus.typesystem as ts
 import math
-#from openmcyclus.depletion import Depletion
+from openmcyclus.depletion import Depletion
 
 class DepleteReactor(Facility):
     '''

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -123,7 +123,7 @@ class DepleteReactor(Facility):
         default = 0
     )
 
-    path = ts.String(
+    model_path = ts.String(
         doc = "Path to files with the OpenMC model information",
         tooltip = "Path to files with OpenMC model",
         default = "/home/abachmann/openmcyclus/tests/"
@@ -131,8 +131,7 @@ class DepleteReactor(Facility):
 
     chain_file = ts.String(
         doc = "File with OpenMC decay chain information",
-        tooltip = "Absolute path to decay chain file",
-        default = "chain_endfb71_pwr.xml"
+        tooltip = "Absolute path to decay chain file"
     )
    
     fresh_fuel = ts.ResBufMaterialInv()
@@ -150,8 +149,8 @@ class DepleteReactor(Facility):
         self.power_name = "power"
         self.discharged = False
         self.resource_indexes = {}
-        self.deplete = Depletion("/home/abachmann/openmcyclus/tests/", 
-                                 "OneReactor", "chain_endfb71_pwr.xml", 
+        self.deplete = Depletion(self.model_path, 
+                                 self.prototype, self.chain_file, 
                                  self.cycle_time, self.power_cap)
 
     def tick(self):
@@ -168,7 +167,6 @@ class DepleteReactor(Facility):
         fuel is loaded
         '''
         print("time:", self.context.time, "tick")
-        #print(self.context.name)
         if self.retired():
             print("time:", self.context.time, "retired")
         #    self.record("RETIRED", "")
@@ -525,8 +523,8 @@ class DepleteReactor(Facility):
             model = self.deplete.read_model()
             micro_xs = self.deplete.read_microxs()
             ind_op = od.IndependentOperator(model.materials, micro_xs,
-                                            "/home/abachmann/openmcyclus/tests/chain_endfb71_pwr.xml")
-            ind_op.output_dir = "/home/abachmann/openmcyclus/tests/"
+                                            str(self.model_path + self.chain_file))
+            ind_op.output_dir = self.model_path
             integrator = od.PredictorIntegrator(ind_op, np.ones(
                 int(self.cycle_time)*30), power=int(self.power_cap)*1000*3, 
                 timestep_units='d')

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -2,7 +2,7 @@ from cyclus.agents import Facility
 from cyclus import lib
 import cyclus.typesystem as ts
 import math
-from openmcyclus.depletion import Depletion
+#from openmcyclus.depletion import Depletion
 
 class DepleteReactor(Facility):
     '''
@@ -126,8 +126,8 @@ class DepleteReactor(Facility):
         self.power_name = "power"
         self.discharged = False
         self.resource_indexes = {}
-        self.deplete = Depletion("tests/", "OneReactor", "chain_endfb71_pwr.xml", 
-                                 self.cycle_time, self.power_cap)
+        #self.deplete = Depletion("tests/", "OneReactor", "chain_endfb71_pwr.xml", 
+        #                         self.cycle_time, self.power_cap)
     def tick(self):
         '''
         Logic to implement at the tick phase of each 

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -6,9 +6,7 @@ import numpy as np
 from openmcyclus.depletion import Depletion
 
 import openmc.deplete as od
-import openmc
-from xml.dom import minidom
-import pathlib
+
 
 
 class DepleteReactor(Facility):

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -2,6 +2,7 @@ from cyclus.agents import Facility
 from cyclus import lib
 import cyclus.typesystem as ts
 import math
+from openmcyclus.depletion import Depletion
 
 class DepleteReactor(Facility):
     '''
@@ -125,7 +126,8 @@ class DepleteReactor(Facility):
         self.power_name = "power"
         self.discharged = False
         self.resource_indexes = {}
-
+        self.deplete = Depletion("tests/", "OneReactor", "chain_endfb71_pwr.xml", 
+                                 self.cycle_time, self.power_cap)
     def tick(self):
         '''
         Logic to implement at the tick phase of each 

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -3,8 +3,6 @@ from cyclus import lib
 import cyclus.typesystem as ts
 import math
 import numpy as np
-#import requests
-#import nb_conda_kernels 
 from openmcyclus.depletion import Depletion
 
 import openmc.deplete as od
@@ -371,7 +369,7 @@ class DepleteReactor(Facility):
                     for kk in range(self.spent_fuel.count):
                         bids.append({'request':req,'offer':mat})
                     if tot_bid >= req.target.quantity:
-                         break
+                        break
             tot_qty = 0
             for mat in mats:
                 tot_qty += mat.quantity

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -2,6 +2,9 @@ from cyclus.agents import Facility
 from cyclus import lib
 import cyclus.typesystem as ts
 import math
+
+#import requests
+#import nb_conda_kernels 
 from openmcyclus.depletion import Depletion
 
 class DepleteReactor(Facility):
@@ -113,6 +116,18 @@ class DepleteReactor(Facility):
               "transmutes half.",
         default = 0
     )
+
+    path = ts.String(
+        doc = "Path to files with the OpenMC model information",
+        tooltip = "Path to files with OpenMC model",
+        default = "/home/abachmann/openmcyclus/tests/"
+    )
+
+    chain_file = ts.String(
+        doc = "File with OpenMC decay chain information",
+        tooltip = "Absolute path to decay chain file",
+        default = "/home/abachmann/openmcyclus/tests/chain_endfb71_pwr.xml"
+    )
    
     fresh_fuel = ts.ResBufMaterialInv()
     core = ts.ResBufMaterialInv()
@@ -129,8 +144,8 @@ class DepleteReactor(Facility):
         self.power_name = "power"
         self.discharged = False
         self.resource_indexes = {}
-        #self.deplete = Depletion("tests/", "OneReactor", "chain_endfb71_pwr.xml", 
-        #                         self.cycle_time, self.power_cap)
+        self.deplete = Depletion(self.path, "OneReactor", self.chain_file, 
+                                 self.cycle_time, self.power_cap)
 
     def tick(self):
         '''
@@ -146,6 +161,7 @@ class DepleteReactor(Facility):
         fuel is loaded
         '''
         print("time:", self.context.time, "tick")
+        #print(self.context.name)
         if self.retired():
             print("time:", self.context.time, "retired")
         #    self.record("RETIRED", "")
@@ -498,7 +514,8 @@ class DepleteReactor(Facility):
         #self.record("TRANSMUTE", ss)
         print("time:", self.context.time, "transmute", ss)
         for ii in range(len(old)):
-            print("call OpenMC")
+            self.deplete.run_depletion()
+            self.deplete.create_recipe()
         return
 
     def record(self, event, val):

--- a/openmcyclus/depletion.py
+++ b/openmcyclus/depletion.py
@@ -59,7 +59,7 @@ class Depletion(object):
         tallies_path = self.path / "tallies.xml"
         if tallies_path.exists():
             model_kwargs["tallies"] = tallies_path
-        model = openmc.Model.from_xml(**model_kwargs)
+        model = openmc.model.model.Model.from_xml(**model_kwargs)
         return model
 
     def read_microxs(self):

--- a/tests/integration_tests/helper.py
+++ b/tests/integration_tests/helper.py
@@ -68,7 +68,7 @@ def run_cyclus(cyclus, cwd, in_path, out_path):
     holdsrtn = [1]  # needed because nose does not send() to test generator
     # make sure the output target directory exists
     cmd = [cyclus, "-o", out_path, "--input-file", in_path]
-    #check_cmd(cmd, cwd, holdsrtn)
+    check_cmd(cmd, cwd, holdsrtn)
 
 
 def check_cmd(args, cwd, holdsrtn):


### PR DESCRIPTION
This PR adds new functionality to the DepleteReactor archetype:
- Call the OpenMC depletion sovler during the `transmute` method
- Write the resulting composition to an xml file 
- Add state variables for the path to the directory with OpenMC model files and the name of the decay chain file 

The CI fails because importing openmc into the archetype (i.e. ``import openmc``) causes a segmentation fault. The seg fault is after the simulation runs and writes the results to the output file and is trying to close python imports (I think). So it all still mostly runs, and I have manually compared the results of the output database to the expected values in the test suite. An issue (#12) has been created to help resolve the seg fault.