### PR TITLE
Added snapshot_inv() and init_inv() to DepleteReactor.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Since last release:
   power (instead of just using `power_cap`) and flux 
   (required input for running OpenMC with new version) (#18)
 * Add CI test to check if CHANGELOG has been updated (#21)
+* Added snapshot_inv() and init_inv() to DepleteReactor.py (#23)
 
 **Changed:**
 
@@ -33,6 +34,7 @@ Since last release:
 
 **Fixed:**
 
+* Fixed the sudden loss of core count in the Tick step when the <explicit_inventroy> flag is on.
 
 v 0.1.0
 =========

--- a/openmcyclus/DepleteReactor.py
+++ b/openmcyclus/DepleteReactor.py
@@ -208,11 +208,14 @@ class DepleteReactor(Facility):
         then the fuel is discharged. If it's after a cycle ends, then
         fuel is loaded
         '''
+        print(f"[TICK] time={self.context.time} | cycle_step={self.cycle_step} | core_count={self.core.count} | discharched={self.discharged}")
         if self.retired():
             if self.context.time == self.exit_time + 1:
+                print("[TICK] Prototype retired, transmuting fuel...")
                 self.transmute()
 
             while self.core.count > 0:
+                print(f"[TICK] Retired: discharging. core_count={self.core.count}")
                 if self.discharge() == False:
                     break
             while (
@@ -221,15 +224,19 @@ class DepleteReactor(Facility):
                 self.spent_fuel.push(self.fresh_fuel.pop())
 
             if self.check_decommission_condition():
+                print("[TICK] Decommissioning...")
                 self.decommission()
 
         if self.cycle_step == self.cycle_time:
+            print("[TICK] End of Cycle, transmuting fuel...")
             self.transmute()
 
         if (self.cycle_step >= self.cycle_time) and (self.discharged == False):
+            print("[TICK] Discharging spent fuel...")
             self.discharged = self.discharge()
 
         if self.cycle_step >= self.cycle_time:
+            print("[TICK] Loading fresh fuel..")
             self.load()
         return
 
@@ -255,6 +262,7 @@ class DepleteReactor(Facility):
         If it's in the middle of a cycle or the core is full, then
         the cycle duration counter increases by one.
         '''
+        print(f"[TOCK] time={self.context.time} | cycle_step={self.cycle_step} | core_count={self.core.count} | discharged={self.discharged}")
         if self.retired():
             return
 
@@ -263,6 +271,7 @@ class DepleteReactor(Facility):
             self.refuel_time) and (
             self.core.count == self.n_assem_core) and (
                 self.discharged):
+            print("[TOCK] Refuel completed, starting new cycle...")
             self.discharged = False
             self.cycle_step = 0
 
@@ -286,6 +295,8 @@ class DepleteReactor(Facility):
         Establish the openmc.deplete.MicroXS and openmc.Materials
         objects for use in simulation.
         '''
+        print(f"[ENTER_NOTIFY] reading materials from: {self.model_path} + materials.xml")
+        print(f"[ENTER_NOTIFY] reading micro_xs from : {self.model_path} + micro_xs.csv")
         super().enter_notify()
         if len(self.fuel_prefs) == 0:
             self.fuel_prefs = [1] * len(self.fuel_incommods)
@@ -343,7 +354,7 @@ class DepleteReactor(Facility):
         ports: list of dictionaries
             Format: [{"commodities":
                       [{commod_name(str):Material object,
-                        "preference":int/float,
+                        "preference":int/float, 
                         "exclusive":Bool}, ...],
                       "constraints:int/float}, ...]
             Defines the request portfolio for the facility.
@@ -568,8 +579,11 @@ class DepleteReactor(Facility):
         --------
         Bool: True if fuel is discharged, false if fuel is not discharged.
         '''
+        print(f"[DISCHARGE] core_count={self.core.count} | spent_fuel_count={self.spent_fuel.count}")
         npop = min(self.n_assem_batch, self.core.count)
+        print(f"[DISCHARGE] npop={npop}")
         if (self.n_assem_spent - self.spent_fuel.count) < npop:
+            print("[DISCHARGE] not enough space for spent fuel, aborting discharge")
             return False
 
         ss = str(npop) + " assemblies"
@@ -590,6 +604,7 @@ class DepleteReactor(Facility):
                 lib.record_time_series(
                     "supply" + self.fuel_outcommods[ii], self, tot_spent)
 
+        print(f"[DISCHARGE] Finished. core_count={self.core.count} | spent_fuel_count={self.spent_fuel.count}")
         return True
 
     def load(self):
@@ -603,7 +618,9 @@ class DepleteReactor(Facility):
         Record the number of assemblies that are to be loaded, then move
         them from the fresh fuel inventory to the core inventory.
         '''
+        print(f"[LOAD] fresh_fuel_count={self.fresh_fuel.count} | core_count={self.core.count}")
         n = min((self.n_assem_core - self.core.count), self.fresh_fuel.count)
+        print(f"[LOAD] loading {n} assemblies")
 
         if n == 0:
             return
@@ -626,24 +643,31 @@ class DepleteReactor(Facility):
         by changing the recipe of the material to that of the
         fuel_outrecipes
         '''
+        print(f"[TRANSMUTE] starting transmute. time={self.context.time} | core_count={self.core.count}")
         assemblies = self.core.pop_n(self.core.count)
+        print(f"[TRANSMUTE] popped {len(assemblies)} assemblies from core.")
         self.core.push_many(assemblies)
+        print("[TRANSMUTE] after push")
         # ss = str(len(assemblies)) + " assemblies"
         # self.record("TRANSMUTE", ss)
         comp_list = [assembly.comp() for assembly in assemblies]
+        print("[Transmute] after comp_list")
         material_ids, materials = self.deplete.update_materials(
             comp_list, self.materials)
+        print("[TRANSMUTE] after material_ids")
         ind_op = od.IndependentOperator(
             materials,
             [np.array([self.flux])] * len(materials),
             [self.micro_xs] * len(materials),
             str(self.model_path + self.chain_file))
         ind_op.output_dir = self.model_path
+        print("[TRANSMUTE] after ind_op")
         integrator = od.PredictorIntegrator(ind_op,
                                             np.ones(int(self.cycle_time)
                                                     ) * self.context.dt,
                                             power=self.thermal_power * 1e6,
                                             timestep_units='s')
+        print("[TRANSMUTE] Running depletion..")
         integrator.integrate()
         spent_comps = self.deplete.get_spent_comps(
             material_ids)
@@ -651,6 +675,7 @@ class DepleteReactor(Facility):
             self.fresh_comps = np.append(self.fresh_comps, assembly.comp())
             self.spent_comps = np.append(self.spent_comps, spent_comp)
             assembly.transmute(spent_comp)
+        print(f"[TRANSMUTE] transmute done. core_count={self.core.count}")
         return
 
     def record(self, event, val):
@@ -843,3 +868,22 @@ class DepleteReactor(Facility):
         position_table.add_val("AgentId", self.id, None, "int")
         position_table.add_val("Latitude", self.latitude, None, "double")
         position_table.add_val("Longitude", self.longitude, None, "double")
+
+
+    def snapshot_inv(self):
+        """returns a dictionary of current inventories"""
+        invs = {
+                "fresh_fuel": list(self.fresh_fuel),
+                "core": list(self.core),
+                "spent_fuel": list(self.spent_fuel)
+                }
+        return invs
+
+    def init_inv(self,invs):
+        """intialized facility inventories"""
+        if "fresh_fuel" in invs:
+            self.fresh_fuel.push_many(invs["fresh_fuel"])
+        if "core" in invs:
+            self.core.push_many(invs["core"])
+        if "spent_fuel" in invs:
+            self.spent_fuel.push_many(invs["spent_fuel"])


### PR DESCRIPTION
## Summary of changes
<!--- In one or more sentences, describe the PR you are submitting. -->
Following the issue of <explicit_inventory> flag in the input causes the core count to drop to zero every time step in the simulation, while this flag doesn't cause any issues in the C++ archetypes. I noticed two main functions that may be responsible to capture the inventory changes when this flag is on.

Two functions are SnapshotInv() and InitInv() as they exist in Cycamore archetypes, so I tried to follow the way they are defined inside Cycamore and added them to OpenMCyclus archetype.

Adding the functions fixed the issue of having an empty core suddenly in Tick, and now the count is correct, compared to running the simulation without the <explicit_inventory> flag at all. 

One bug that still persists is that during the transmutation step, the fuel still doesn't go through the depletion step and jumps directly to discharging. My thoughts are that those two functions still need some edits, or to be defined in some other way to be able to capture the full functionality.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request. -->

- Issue: #23 


## Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->

- Dev: @abachma2 


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the
Review Checklist before they begin their review.
